### PR TITLE
multi-project version of gdw.

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -12,7 +12,20 @@ alias ll="ls -la"
 
 ## Gralde
 alias gdl="gradle"
-alias gdw="./gradlew"
+
+gdw() {
+    _GDW_DIR=$(pwd)
+
+    while [ "$_GDW_DIR" != "/" ]; do
+        _GDW_PATH="$_GDW_DIR/gradlew"
+        if [ -f $_GDW_PATH ]; then
+            $_GDW_PATH "$@"
+            break;
+        fi
+
+        _GDW_DIR=$(dirname $_GDW_DIR)
+    done
+}
 
 ## Resets SVN working copy, reverting all changed files and removing all unversioned files. Usage: svn reset
 svn() { 


### PR DESCRIPTION
looks up gradlew all the way up in the directory hierarchy and calls the first match. works well for multi-project setup, where gradlew might be in the parent directory.
